### PR TITLE
Use new nb format for project description

### DIFF
--- a/manifest.scm
+++ b/manifest.scm
@@ -1,3 +1,4 @@
+;;; Quantitative Genetics Tools for Mapping Trait Variation to Mechanisms, Therapeutics, and Interventions - Webinar Series 
 (specifications->manifest
   '("r-qtl"
     "r-vioplot"))


### PR DESCRIPTION
Hi @sens,

Hope all is well!

The new [nb](https://git.genenetwork.org/jgart/nb) app in common lisp searches in the guix manifest for a project description. This allows to not have to deal with discrepancies across git forge APIs (binderlite made http requests to github's API but we need to support all forges in a simple way so we parse the head of the manifest instead for the project description)

The format is three semicolons followed by a space and the description.

I have added the proper format in the PR for you to merge after review.

See [this line](https://git.genenetwork.org/jgart/nb/src/branch/master/src/nb.lisp#L41) if interested in the implementation.